### PR TITLE
Add original_code field to unreviewed files handling

### DIFF
--- a/src/components/ConversionViewer.tsx
+++ b/src/components/ConversionViewer.tsx
@@ -114,7 +114,8 @@ const ConversionViewer: React.FC<ConversionViewerProps> = ({
     const success = await addUnreviewedFile({
       user_id: '', // This will be set by the hook
       file_name: file.name,
-      converted_code: file.convertedContent
+      converted_code: file.convertedContent,
+      original_code: file.content,
     });
 
     if (success) {

--- a/src/components/PendingActionsPanel.tsx
+++ b/src/components/PendingActionsPanel.tsx
@@ -135,6 +135,16 @@ const PendingActionsPanel: React.FC = () => {
                 <CardContent className="space-y-4">
                   <div>
                     <label className="text-sm font-medium mb-2 block">
+                      Original Code:
+                    </label>
+                    <ScrollArea className="h-[120px] w-full rounded-md border mb-2">
+                      <pre className="p-4 text-sm font-mono whitespace-pre-wrap">
+                        {file.original_code}
+                      </pre>
+                    </ScrollArea>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium mb-2 block">
                       Converted Code:
                     </label>
                     {editingFile === file.id ? (

--- a/src/hooks/useUnreviewedFiles.tsx
+++ b/src/hooks/useUnreviewedFiles.tsx
@@ -47,7 +47,8 @@ export const useUnreviewedFiles = () => {
         .insert({
           ...fileData,
           user_id: user.id,
-          status: 'unreviewed'
+          status: 'unreviewed',
+          original_code: fileData.original_code,
         });
 
       if (error) throw error;
@@ -78,6 +79,7 @@ export const useUnreviewedFiles = () => {
         .from('unreviewed_files')
         .update({
           converted_code: updateData.converted_code,
+          original_code: updateData.original_code,
           status: updateData.status,
           updated_at: new Date().toISOString()
         })

--- a/src/hooks/useUnreviewedFiles.tsx
+++ b/src/hooks/useUnreviewedFiles.tsx
@@ -111,6 +111,15 @@ export const useUnreviewedFiles = () => {
     if (!user) return false;
 
     try {
+      // Fetch the unreviewed file to get the original_code
+      const { data: unreviewedFileData, error: fetchError } = await supabase
+        .from('unreviewed_files')
+        .select('original_code')
+        .eq('id', id)
+        .single();
+      if (fetchError) throw fetchError;
+      const originalCode = unreviewedFileData?.original_code || '';
+
       // First, add to migration history
       const { data: migration, error: migrationError } = await supabase
         .from('migrations')
@@ -132,6 +141,7 @@ export const useUnreviewedFiles = () => {
           file_path: fileName,
           file_type: 'other',
           converted_content: convertedCode,
+          original_content: originalCode,
           conversion_status: 'success'
         });
 

--- a/src/hooks/useUnreviewedFiles.tsx
+++ b/src/hooks/useUnreviewedFiles.tsx
@@ -111,14 +111,15 @@ export const useUnreviewedFiles = () => {
     if (!user) return false;
 
     try {
-      // Fetch the unreviewed file to get the original_code
+      // Fetch the unreviewed file to get the original_code and type
       const { data: unreviewedFileData, error: fetchError } = await supabase
         .from('unreviewed_files')
-        .select('original_code')
+        .select('original_code, type')
         .eq('id', id)
         .single();
       if (fetchError) throw fetchError;
       const originalCode = unreviewedFileData?.original_code || '';
+      const fileType = unreviewedFileData?.type || 'other';
 
       // First, add to migration history
       const { data: migration, error: migrationError } = await supabase
@@ -139,7 +140,7 @@ export const useUnreviewedFiles = () => {
           migration_id: migration.id,
           file_name: fileName,
           file_path: fileName,
-          file_type: 'other',
+          file_type: fileType,
           converted_content: convertedCode,
           original_content: originalCode,
           conversion_status: 'success'

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -185,6 +185,7 @@ export type Database = {
           created_at: string
           file_name: string
           id: string
+          original_code: string
           status: string
           updated_at: string
           user_id: string
@@ -194,6 +195,7 @@ export type Database = {
           created_at?: string
           file_name: string
           id?: string
+          original_code: string
           status?: string
           updated_at?: string
           user_id: string
@@ -203,6 +205,7 @@ export type Database = {
           created_at?: string
           file_name?: string
           id?: string
+          original_code?: string
           status?: string
           updated_at?: string
           user_id?: string

--- a/src/types/unreviewedFiles.ts
+++ b/src/types/unreviewedFiles.ts
@@ -3,6 +3,7 @@ export interface UnreviewedFile {
   user_id: string;
   file_name: string;
   converted_code: string;
+  original_code: string;
   status: 'unreviewed' | 'reviewed';
   created_at: string;
   updated_at: string;
@@ -12,11 +13,13 @@ export interface UnreviewedFileInsert {
   user_id: string;
   file_name: string;
   converted_code: string;
+  original_code: string;
   status?: 'unreviewed' | 'reviewed';
 }
 
 export interface UnreviewedFileUpdate {
   id: string;
   converted_code?: string;
+  original_code?: string;
   status?: 'unreviewed' | 'reviewed';
 }


### PR DESCRIPTION
- Updated ConversionViewer to include original_code when adding unreviewed files.
- Enhanced PendingActionsPanel to display original_code alongside converted_code.
- Modified useUnreviewedFiles hook to handle original_code in insert and update operations.
- Updated Supabase types and interfaces to include original_code for unreviewed files.