### PR TITLE
Add readOnly prop to CodeDiffViewer for enhanced control over editing

### DIFF
--- a/src/components/CodeDiffViewer.tsx
+++ b/src/components/CodeDiffViewer.tsx
@@ -7,12 +7,14 @@ interface CodeDiffViewerProps {
   originalCode: string;
   convertedCode: string;
   onUpdateConvertedCode?: (updatedCode: string) => void;
+  readOnly?: boolean;
 }
 
 const CodeDiffViewer: React.FC<CodeDiffViewerProps> = ({
   originalCode,
   convertedCode,
   onUpdateConvertedCode,
+  readOnly = false,
 }) => {
   return (
     <Card className="w-full">
@@ -34,7 +36,7 @@ const CodeDiffViewer: React.FC<CodeDiffViewerProps> = ({
             <h3 className="text-sm font-medium mb-2 text-muted-foreground">Converted (Oracle)</h3>
             <CodeEditor 
               initialCode={convertedCode} 
-              readOnly={false} 
+              readOnly={readOnly} 
               onSave={onUpdateConvertedCode}
               height="500px"
               language="plsql"

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -535,6 +535,7 @@ const History = () => {
                 <CodeDiffViewer
                   originalCode={selectedFile.original_content || ''}
                   convertedCode={selectedFile.converted_content || selectedFile.original_content || 'No converted code available'}
+                  readOnly={true}
                 />
               )}
             </div>


### PR DESCRIPTION
- Introduced a readOnly prop to CodeDiffViewer, allowing for better control over the editing state of the converted code.
- Updated the History page to set readOnly to true when displaying the CodeDiffViewer, ensuring users cannot modify the converted code in this context.