### PR TITLE
Add reset migration functionality to FileTreeView and ConversionPanel

### DIFF
--- a/src/components/FileTreeView.tsx
+++ b/src/components/FileTreeView.tsx
@@ -48,6 +48,7 @@ interface FileTreeViewProps {
   statusFilter?: string;
   onSearchTermChange?: (term: string) => void;
   onStatusFilterChange?: (status: string) => void;
+  onResetMigration?: () => void;
 }
 
 const FileTreeView: React.FC<FileTreeViewProps> = ({
@@ -67,6 +68,7 @@ const FileTreeView: React.FC<FileTreeViewProps> = ({
   statusFilter = 'All',
   onSearchTermChange,
   onStatusFilterChange,
+  onResetMigration,
 }) => {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(
     new Set(defaultExpandedSections)
@@ -232,9 +234,10 @@ const FileTreeView: React.FC<FileTreeViewProps> = ({
           <div className="flex flex-row items-center justify-between w-full mb-2">
             <CardTitle className="text-lg">Project Structure</CardTitle>
             <div className="flex gap-2">
-              {onClear && files.length > 0 && (
-                <Button variant="destructive" onClick={onClear} className="text-xs px-3 py-1 h-7">
-                  Clear
+              {/* Only show Reset Migration button, not Clear */}
+              {onResetMigration && (
+                <Button variant="destructive" onClick={onResetMigration} className="text-xs px-3 py-1 h-7">
+                  Reset Migration
                 </Button>
               )}
               {onConvertAll && totalPending > 0 && (

--- a/src/components/dashboard/ConversionPanel.tsx
+++ b/src/components/dashboard/ConversionPanel.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { FileText, Download } from 'lucide-react';
 import FileTreeView from '@/components/FileTreeView';
 import ConversionViewer from '@/components/ConversionViewer';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 
 interface FileItem {
   id: string;
@@ -103,6 +104,21 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({
   const hasPrev = currentIndex > 0;
   const hasNext = currentIndex >= 0 && currentIndex < allFilteredFiles.length - 1;
 
+  const [showResetDialog, setShowResetDialog] = React.useState(false);
+
+  const handleResetMigration = () => {
+    setShowResetDialog(true);
+  };
+  const confirmResetMigration = () => {
+    setShowResetDialog(false);
+    if (typeof onUploadRedirect === 'function') {
+      onUploadRedirect();
+    }
+  };
+  const cancelResetMigration = () => {
+    setShowResetDialog(false);
+  };
+
   return (
     <div className="grid grid-cols-12 gap-6">
       <div className="col-span-4">
@@ -116,14 +132,27 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({
           selectedFile={selectedFile}
           isConverting={isConverting}
           convertingFileIds={convertingFileIds}
-          onClear={onClear}
           hideActions={false}
           defaultExpandedSections={['tables','procedures','triggers']}
           searchTerm={searchTerm}
           statusFilter={statusFilter}
           onSearchTermChange={setSearchTerm}
           onStatusFilterChange={setStatusFilter}
+          onResetMigration={handleResetMigration}
         />
+        {/* Confirmation Dialog for Reset Migration */}
+        <Dialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Reset Migration?</DialogTitle>
+            </DialogHeader>
+            <div className="py-2">Are you sure you want to reset the current migration? This will clear all uploaded files and progress.</div>
+            <DialogFooter>
+              <Button variant="outline" onClick={cancelResetMigration}>Cancel</Button>
+              <Button variant="destructive" onClick={confirmResetMigration}>OK</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
 
       <div className="col-span-8">


### PR DESCRIPTION
- Introduced a new prop `onResetMigration` in the FileTreeView component to handle migration resets.
- Implemented a confirmation dialog in the ConversionPanel for resetting migrations, allowing users to confirm or cancel the action before proceeding.